### PR TITLE
Fix import module name in unit test

### DIFF
--- a/import_test.go
+++ b/import_test.go
@@ -24,9 +24,9 @@ func TestImportModule(t *testing.T) {
 func TestImportModuleEx(t *testing.T) {
 	Py_Initialize()
 
-	test := PyImport_ImportModuleEx("test", nil, nil, nil)
-	assert.NotNil(t, test)
-	test.DecRef()
+	queue := PyImport_ImportModuleEx("queue", nil, nil, nil)
+	assert.NotNil(t, queue)
+	queue.DecRef()
 }
 
 func TestImportModuleLevelObject(t *testing.T) {

--- a/module_test.go
+++ b/module_test.go
@@ -99,16 +99,13 @@ func TestModuleGetState(t *testing.T) {
 func TestModuleGetFilenameObject(t *testing.T) {
 	Py_Initialize()
 
-	name := "test"
-	pyName := PyUnicode_FromString(name)
-	defer pyName.DecRef()
+	name := "queue"
+	queue := PyImport_ImportModule(name)
+	defer queue.DecRef()
 
-	test := PyImport_ImportModule(name)
-	defer test.DecRef()
-
-	pyFilename := PyModule_GetFilenameObject(test)
+	pyFilename := PyModule_GetFilenameObject(queue)
 	assert.NotNil(t, pyFilename)
 	filename := PyUnicode_AsUTF8(pyFilename)
 
-	assert.True(t, strings.Contains(filename, "/test/__init__.py"))
+	assert.True(t, strings.HasSuffix(filename, "/queue.py"))
 }


### PR DESCRIPTION
### What does this PR do?

Fix import module name in unit test. After that, it can pass the go test.

### Motivation

`PyImport_ImportModule` would return nil with importing the package of `test`. I couldn't pass the unit test in python:3.7 official image. And it not been recommended to used outside by [official documentation](https://docs.python.org/3.7/library/test.html?highlight=test#module-test).

### Additional Notes

Running `go test` need creating go.mod. I created one for myself test. This PR does not include go.mod.

